### PR TITLE
Add Cucumber options support

### DIFF
--- a/integration-tests/src/test/java/io/quarkiverse/cucumber/it/Steps.java
+++ b/integration-tests/src/test/java/io/quarkiverse/cucumber/it/Steps.java
@@ -1,14 +1,13 @@
 package io.quarkiverse.cucumber.it;
 
-import static io.restassured.RestAssured.given;
-
 import javax.inject.Inject;
-
-import org.eclipse.microprofile.config.inject.ConfigProperty;
 
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.restassured.response.ValidatableResponse;
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+import static io.restassured.RestAssured.given;
 
 public class Steps {
 
@@ -17,6 +16,11 @@ public class Steps {
     String target;
 
     private ValidatableResponse result;
+
+    @Given("^print \"(.+)\"$")
+    public void print(String message) throws Exception {
+        System.out.println(message);
+    }
 
     @Given("I call the endpoint")
     public void i_call_endpoint() throws Exception {

--- a/integration-tests/src/test/java/io/quarkiverse/cucumber/it/options/CucumberOptionsTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/cucumber/it/options/CucumberOptionsTest.java
@@ -1,0 +1,8 @@
+package io.quarkiverse.cucumber.it.options;
+
+import io.quarkiverse.cucumber.CucumberOptions;
+import io.quarkiverse.cucumber.CucumberQuarkusTest;
+
+@CucumberOptions(glue = { "io.quarkiverse.cucumber.it" }, tags = "@important", plugin = { "json" })
+public class CucumberOptionsTest extends CucumberQuarkusTest {
+}

--- a/integration-tests/src/test/resources/io/quarkiverse/cucumber/it/options/options.feature
+++ b/integration-tests/src/test/resources/io/quarkiverse/cucumber/it/options/options.feature
@@ -1,0 +1,5 @@
+Feature: Test Cucumber options
+
+  @important
+  Scenario: Test scenario
+    Given print "Quarkus rocks!"

--- a/runtime/src/main/java/io/quarkiverse/cucumber/CucumberOptions.java
+++ b/runtime/src/main/java/io/quarkiverse/cucumber/CucumberOptions.java
@@ -1,0 +1,128 @@
+package io.quarkiverse.cucumber;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import io.cucumber.core.backend.ObjectFactory;
+import io.cucumber.core.snippets.SnippetType;
+import io.cucumber.plugin.Plugin;
+import org.apiguardian.api.API;
+
+/**
+ * Configures Cucumbers options via class type annotation.
+ * Derived from JUnit4 CucumberOptions.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.TYPE })
+@API(status = API.Status.STABLE)
+public @interface CucumberOptions {
+
+    /**
+     * @return true if glue code execution should be skipped.
+     */
+    boolean dryRun() default false;
+
+    /**
+     * Either a URI or path to a directory of features or a URI or path to a
+     * single feature optionally followed by a colon and line numbers.
+     * <p>
+     * When no feature path is provided, Cucumber will use the package of the
+     * annotated class. For example, if the annotated class is
+     * {@code com.example.RunCucumber} then features are assumed to be located
+     * in {@code classpath:com/example}.
+     *
+     * @return list of files or directories
+     * @see io.cucumber.core.feature.FeatureWithLines
+     */
+    String[] features() default {};
+
+    /**
+     * Package to load glue code (step definitions, hooks and plugins) from.
+     * E.g: {@code com.example.app}
+     * <p>
+     * When no glue is provided, Cucumber will use the package of the annotated
+     * class. For example, if the annotated class is
+     * {@code com.example.RunCucumber} then glue is assumed to be located in
+     * {@code com.example}.
+     *
+     * @return list of package names
+     * @see io.cucumber.core.feature.GluePath
+     */
+    String[] glue() default {};
+
+    /**
+     * Package to load additional glue code (step definitions, hooks and
+     * plugins) from. E.g: {@code com.example.app}
+     * <p>
+     * These packages are used in addition to the default described in
+     * {@code #glue}.
+     *
+     * @return list of package names
+     */
+    String[] extraGlue() default {};
+
+    /**
+     * Only run scenarios tagged with tags matching {@code TAG_EXPRESSION}.
+     * <p>
+     * For example {@code "@smoke and not @fast"}.
+     *
+     * @return a tag expression
+     */
+    String tags() default "";
+
+    /**
+     * Register plugins. Built-in plugin types: {@code junit}, {@code html},
+     * {@code pretty}, {@code progress}, {@code json}, {@code usage},
+     * {@code unused}, {@code rerun}, {@code testng}.
+     * <p>
+     * Can also be a fully qualified class name, allowing registration of 3rd
+     * party plugins.
+     * <p>
+     * Plugins can be provided with an argument. For example
+     * {@code json:target/cucumber-report.json}
+     *
+     * @return list of plugins
+     * @see Plugin
+     */
+    String[] plugin() default {};
+
+    /**
+     * Publish report to https://reports.cucumber.io.
+     * <p>
+     *
+     * @return true if reports should be published on the web.
+     */
+    boolean publish() default false;
+
+    /**
+     * @return true if terminal output should be without colours.
+     */
+    boolean monochrome() default false;
+
+    /**
+     * Only run scenarios whose names match one of the provided regular
+     * expressions.
+     *
+     * @return a list of regular expressions
+     */
+    String[] name() default {};
+
+    /**
+     * @return the format of the generated snippets.
+     */
+    SnippetType snippets() default SnippetType.UNDERSCORE;
+
+    /**
+     * Specify a custom ObjectFactory.
+     * <p>
+     * In case a custom ObjectFactory is needed, the class can be specified
+     * here. A custom ObjectFactory might be needed when more granular control
+     * is needed over the dependency injection mechanism.
+     *
+     * @return an {@link io.cucumber.core.backend.ObjectFactory} implementation
+     */
+    Class<? extends ObjectFactory> objectFactory() default CucumberQuarkusTest.CdiObjectFactory.class;
+
+}

--- a/runtime/src/main/java/io/quarkiverse/cucumber/CucumberQuarkusTest.java
+++ b/runtime/src/main/java/io/quarkiverse/cucumber/CucumberQuarkusTest.java
@@ -1,5 +1,7 @@
 package io.quarkiverse.cucumber;
 
+import javax.enterprise.inject.Instance;
+import javax.enterprise.inject.spi.CDI;
 import java.time.Clock;
 import java.util.Collections;
 import java.util.LinkedList;
@@ -7,19 +9,12 @@ import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
 
-import javax.enterprise.inject.Instance;
-import javax.enterprise.inject.spi.CDI;
-
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.DynamicContainer;
-import org.junit.jupiter.api.DynamicNode;
-import org.junit.jupiter.api.DynamicTest;
-import org.junit.jupiter.api.TestFactory;
-
 import io.cucumber.core.backend.ObjectFactory;
 import io.cucumber.core.eventbus.EventBus;
 import io.cucumber.core.feature.FeatureParser;
-import io.cucumber.core.options.CommandlineOptionsParser;
+import io.cucumber.core.options.CucumberOptionsAnnotationParser;
+import io.cucumber.core.options.CucumberProperties;
+import io.cucumber.core.options.CucumberPropertiesParser;
 import io.cucumber.core.options.RuntimeOptions;
 import io.cucumber.core.options.RuntimeOptionsBuilder;
 import io.cucumber.core.plugin.PluginFactory;
@@ -40,6 +35,11 @@ import io.cucumber.plugin.event.PickleStepTestStep;
 import io.cucumber.plugin.event.Status;
 import io.cucumber.plugin.event.TestStepFinished;
 import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DynamicContainer;
+import org.junit.jupiter.api.DynamicNode;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.TestFactory;
 
 @QuarkusTest
 public abstract class CucumberQuarkusTest {
@@ -49,17 +49,37 @@ public abstract class CucumberQuarkusTest {
         EventBus eventBus = new TimeServiceEventBus(Clock.systemUTC(), UUID::randomUUID);
         final FeatureParser parser = new FeatureParser(eventBus::generateId);
 
-        RuntimeOptionsBuilder commandlineOptionsParser = new CommandlineOptionsParser(System.out).parse();
+        RuntimeOptions propertiesFileOptions = new CucumberPropertiesParser()
+                .parse(CucumberProperties.fromPropertiesFile())
+                .build();
 
-        RuntimeOptionsBuilder runtimeOptionsBuilder = new RuntimeOptionsBuilder();
-        runtimeOptionsBuilder.addDefaultFeaturePathIfAbsent();
-        runtimeOptionsBuilder.addDefaultGlueIfAbsent();
-        runtimeOptionsBuilder.addDefaultFormatterIfAbsent();
-        runtimeOptionsBuilder.addDefaultSummaryPrinterIfAbsent();
+        RuntimeOptions environmentOptions = new CucumberPropertiesParser()
+                .parse(CucumberProperties.fromEnvironment())
+                .build(propertiesFileOptions);
 
-        //runtimeOptionsBuilder.addGlue(URI.create("classpath:/" + Steps.class.getPackage().getName().replace(".", "/")));
+        RuntimeOptions systemOptions = new CucumberPropertiesParser()
+                .parse(CucumberProperties.fromSystemProperties())
+                .build(environmentOptions);
 
-        RuntimeOptions runtimeOptions = runtimeOptionsBuilder.build(commandlineOptionsParser.build());
+        RuntimeOptions runtimeOptions;
+        RuntimeOptionsBuilder runtimeOptionsBuilder = new RuntimeOptionsBuilder()
+                .addDefaultFeaturePathIfAbsent()
+                .addDefaultGlueIfAbsent()
+                .addDefaultFormatterIfAbsent()
+                .addDefaultSummaryPrinterIfAbsent();
+
+        QuarkusCucumberOptionsProvider optionsProvider = new QuarkusCucumberOptionsProvider();
+        if (optionsProvider.hasOptions(this.getClass())) {
+            CucumberOptionsAnnotationParser annotationParser = new CucumberOptionsAnnotationParser()
+                    .withOptionsProvider(optionsProvider);
+            RuntimeOptions annotationOptions = annotationParser
+                    .parse(this.getClass())
+                    .build(systemOptions);
+            runtimeOptions = runtimeOptionsBuilder.build(annotationOptions);
+        } else {
+            runtimeOptions = runtimeOptionsBuilder.build(systemOptions);
+        }
+
         FeatureSupplier featureSupplier = new FeaturePathFeatureSupplier(() -> Thread.currentThread().getContextClassLoader(),
                 runtimeOptions, parser);
 

--- a/runtime/src/main/java/io/quarkiverse/cucumber/QuarkusCucumberOptionsProvider.java
+++ b/runtime/src/main/java/io/quarkiverse/cucumber/QuarkusCucumberOptionsProvider.java
@@ -1,0 +1,105 @@
+package io.quarkiverse.cucumber;
+
+import io.cucumber.core.backend.ObjectFactory;
+import io.cucumber.core.options.CucumberOptionsAnnotationParser;
+import io.cucumber.core.snippets.SnippetType;
+
+/**
+ * Options provider reads {@link io.quarkiverse.cucumber.CucumberOptions} on given test class.
+ * Derived from JUnit4 Cucumber options provider.
+ */
+public class QuarkusCucumberOptionsProvider implements CucumberOptionsAnnotationParser.OptionsProvider {
+
+    @Override
+    public CucumberOptionsAnnotationParser.CucumberOptions getOptions(Class<?> clazz) {
+        if (hasOptions(clazz)) {
+            CucumberOptions annotation = clazz.getAnnotation(CucumberOptions.class);
+            return new QuarkusCucumberOptionsProvider.QuarkusCucumberOptions(annotation);
+        }
+
+        return null;
+    }
+
+    /**
+     * Checks if {@link io.quarkiverse.cucumber.CucumberOptions} annotation is present on given class.
+     *
+     * @param clazz
+     * @return
+     */
+    public boolean hasOptions(Class<?> clazz) {
+        return clazz.getAnnotation(CucumberOptions.class) != null;
+    }
+
+    /**
+     * Options implementation using given annotation to retrieve Cucumber settings.
+     */
+    private static class QuarkusCucumberOptions implements CucumberOptionsAnnotationParser.CucumberOptions {
+
+        private final CucumberOptions annotation;
+
+        QuarkusCucumberOptions(CucumberOptions annotation) {
+            this.annotation = annotation;
+        }
+
+        @Override
+        public boolean dryRun() {
+            return annotation.dryRun();
+        }
+
+        @Override
+        public boolean strict() {
+            return true;
+        }
+
+        @Override
+        public String[] features() {
+            return annotation.features();
+        }
+
+        @Override
+        public String[] glue() {
+            return annotation.glue();
+        }
+
+        @Override
+        public String[] extraGlue() {
+            return annotation.extraGlue();
+        }
+
+        @Override
+        public String tags() {
+            return annotation.tags();
+        }
+
+        @Override
+        public String[] plugin() {
+            return annotation.plugin();
+        }
+
+        @Override
+        public boolean publish() {
+            return annotation.publish();
+        }
+
+        @Override
+        public boolean monochrome() {
+            return annotation.monochrome();
+        }
+
+        @Override
+        public String[] name() {
+            return annotation.name();
+        }
+
+        @Override
+        public SnippetType snippets() {
+            return annotation.snippets();
+        }
+
+        @Override
+        public Class<? extends ObjectFactory> objectFactory() {
+            return annotation.objectFactory();
+        }
+
+    }
+}


### PR DESCRIPTION
Load Cucumber options via
- cucumber.properties file
- environment variables
- system property settings
- annotation configuration

Remove command line options parsing as no args are present when running the test via QuarkusTest runtime.

Cucumber options allow to specify/add glue code (step implementations in different packages). Also usage of tag filters and plugin configuration is controlled via Cucumber options. See the list of [available CucumberOptions](https://cucumber.io/docs/cucumber/api/#options) for more settings.

This PR uses the JUnit4 CucumberOptions as a basis and applies the option parsers provided by Cucumber to the Quarkus test runtime. The CucumberOptions annotation configuration can be applied per @QuarkusTest class.