### PR TITLE
Fix Cucumber tags filtering support

### DIFF
--- a/integration-tests/src/test/resources/io/quarkiverse/cucumber/it/options/options.feature
+++ b/integration-tests/src/test/resources/io/quarkiverse/cucumber/it/options/options.feature
@@ -3,3 +3,7 @@ Feature: Test Cucumber options
   @important
   Scenario: Test scenario
     Given print "Quarkus rocks!"
+
+  @ignored
+  Scenario: Ignored scenario
+    Given print "should not run!"


### PR DESCRIPTION
Do not run scenarios based on tag filter provided in Cucumber options. When all scenarios in a feature get filtered by tags do not run the feature at all.

Relates to #3 