### PR TITLE
feat: link test source uri to features and scenarios

### DIFF
--- a/runtime/src/main/java/io/quarkiverse/cucumber/CucumberQuarkusTest.java
+++ b/runtime/src/main/java/io/quarkiverse/cucumber/CucumberQuarkusTest.java
@@ -148,7 +148,6 @@ public abstract class CucumberQuarkusTest {
      * @param uri      file uri of feature or scenario retrieved from
      * @param location location in a file, specifically the line
      * @return URI compatible with Junit
-     * @throws URISyntaxException
      */
     private static URI getTestSourceUri(@NotNull URI uri, @NotNull Location location) {
         return Optional.of(uri)


### PR DESCRIPTION
This change will allow users in IDE's to locate exactly selected feature. Before that it was opening `CucumberQuarkusTest` on any selection.
Hard to figure out the unit tests part here, as I understand the integration tests are the only available ones now
fixes #101