### PR TITLE
Upgrade the version of cucumber to 7.15.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.version>3.0.3.Final</quarkus.version>
-    <cucumber.version>7.11.2</cucumber.version>
+    <cucumber.version>7.14.0</cucumber.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.version>3.0.3.Final</quarkus.version>
-    <cucumber.version>7.14.0</cucumber.version>
+    <cucumber.version>7.15.0</cucumber.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/runtime/src/main/java/io/quarkiverse/cucumber/CucumberQuarkusTest.java
+++ b/runtime/src/main/java/io/quarkiverse/cucumber/CucumberQuarkusTest.java
@@ -104,19 +104,7 @@ public abstract class CucumberQuarkusTest {
         } else {
             plugins.setEventBusOnEventListenerPlugins(eventBus);
         }
-        ObjectFactory objectFactory = new CdiObjectFactory();
-
-        ObjectFactorySupplier objectFactorySupplier = () -> objectFactory;
-
-        Runner runner = new Runner(eventBus,
-                Collections.singleton(new JavaBackendProviderService().create(objectFactorySupplier.get(),
-                        objectFactorySupplier.get(),
-                        () -> Thread.currentThread()
-                                .getContextClassLoader())),
-                objectFactorySupplier.get(),
-                runtimeOptions);
-
-        CucumberExecutionContext context = new CucumberExecutionContext(eventBus, exitStatus, () -> runner);
+        CucumberExecutionContext context = cucumberExecutionContext(eventBus, runtimeOptions, exitStatus);
 
         List<DynamicNode> features = new LinkedList<>();
         features.add(DynamicTest.dynamicTest("Start Cucumber", context::startTestRun));
@@ -170,6 +158,23 @@ public abstract class CucumberQuarkusTest {
         features.add(DynamicTest.dynamicTest("Finish Cucumber", context::finishTestRun));
 
         return features;
+    }
+
+    private static CucumberExecutionContext cucumberExecutionContext(EventBus eventBus, RuntimeOptions runtimeOptions,
+            ExitStatus exitStatus) {
+        ObjectFactory objectFactory = new CdiObjectFactory();
+
+        ObjectFactorySupplier objectFactorySupplier = () -> objectFactory;
+
+        Runner runner = new Runner(eventBus,
+                Collections.singleton(new JavaBackendProviderService().create(objectFactorySupplier.get(),
+                        objectFactorySupplier.get(),
+                        () -> Thread.currentThread()
+                                .getContextClassLoader())),
+                objectFactorySupplier.get(),
+                runtimeOptions);
+
+        return new CucumberExecutionContext(eventBus, exitStatus, () -> runner);
     }
 
     public static class CdiObjectFactory implements ObjectFactory {

--- a/runtime/src/main/java/io/quarkiverse/cucumber/QuarkusCucumberOptionsProvider.java
+++ b/runtime/src/main/java/io/quarkiverse/cucumber/QuarkusCucumberOptionsProvider.java
@@ -1,6 +1,9 @@
 package io.quarkiverse.cucumber;
 
+import java.util.UUID;
+
 import io.cucumber.core.backend.ObjectFactory;
+import io.cucumber.core.eventbus.UuidGenerator;
 import io.cucumber.core.options.CucumberOptionsAnnotationParser;
 import io.cucumber.core.snippets.SnippetType;
 
@@ -96,5 +99,17 @@ public class QuarkusCucumberOptionsProvider implements CucumberOptionsAnnotation
             return annotation.objectFactory();
         }
 
+        @Override
+        public Class<? extends UuidGenerator> uuidGenerator() {
+            return DefaultUuidGenerator.class;
+        }
+
+    }
+
+    public static final class DefaultUuidGenerator implements UuidGenerator {
+        @Override
+        public UUID generateId() {
+            return UUID.randomUUID();
+        }
     }
 }


### PR DESCRIPTION
Upgrading the version of cucumber to the last stable version 7.15.0 can bring bug fixing and performance improvements since the last version used in the library 

For more details please refer to https://github.com/cucumber/cucumber-jvm/blob/main/CHANGELOG.md 
