### PR TITLE
Upgrade version of Quarkus to the latest stable LTS 3.2.6.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <url>https://github.com/quarkiverse/quarkus-cucumber</url>
   </scm>
   <properties>
-    <compiler-plugin.version>3.8.1</compiler-plugin.version>
+    <compiler-plugin.version>3.11.0</compiler-plugin.version>
     <maven.compiler.parameters>true</maven.compiler.parameters>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>

--- a/pom.xml
+++ b/pom.xml
@@ -22,14 +22,13 @@
     <url>https://github.com/quarkiverse/quarkus-cucumber</url>
   </scm>
   <properties>
-    <compiler-plugin.version>3.11.0</compiler-plugin.version>
     <maven.compiler.parameters>true</maven.compiler.parameters>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <quarkus.version>3.6.6</quarkus.version>
-    <cucumber.version>7.15.0</cucumber.version>
+    <quarkus.version>3.2.6.Final</quarkus.version>
+    <cucumber.version>7.11.2</cucumber.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <maven.compiler.target>11</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <quarkus.version>3.0.3.Final</quarkus.version>
+    <quarkus.version>3.6.1</quarkus.version>
     <cucumber.version>7.15.0</cucumber.version>
   </properties>
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
     <url>https://github.com/quarkiverse/quarkus-cucumber</url>
   </scm>
   <properties>
+    <compiler-plugin.version>3.8.1</compiler-plugin.version>
     <maven.compiler.parameters>true</maven.compiler.parameters>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.version>3.2.6.Final</quarkus.version>
-    <cucumber.version>7.11.2</cucumber.version>
+    <cucumber.version>7.15.0</cucumber.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <maven.compiler.target>11</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <quarkus.version>3.6.2</quarkus.version>
+    <quarkus.version>3.6.6</quarkus.version>
     <cucumber.version>7.15.0</cucumber.version>
   </properties>
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <maven.compiler.target>11</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <quarkus.version>3.6.1</quarkus.version>
+    <quarkus.version>3.6.2</quarkus.version>
     <cucumber.version>7.15.0</cucumber.version>
   </properties>
   <dependencyManagement>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -51,18 +51,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <annotationProcessorPaths>
-                        <path>
-                            <groupId>io.quarkus</groupId>
-                            <artifactId>quarkus-extension-processor</artifactId>
-                            <version>${quarkus.version}</version>
-                        </path>
-                    </annotationProcessorPaths>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 </project>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -51,6 +51,18 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.quarkus</groupId>
+                            <artifactId>quarkus-extension-processor</artifactId>
+                            <version>${quarkus.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
Upgrading the version of Quarkus to the latest one stable TLS one 3.2.6.Final

