### PR TITLE
feat(#14): provide a @ScenarioScope annotation

### DIFF
--- a/integration-tests/src/test/java/io/quarkiverse/cucumber/it/StatefulSteps.java
+++ b/integration-tests/src/test/java/io/quarkiverse/cucumber/it/StatefulSteps.java
@@ -1,0 +1,26 @@
+package io.quarkiverse.cucumber.it;
+
+import java.util.Objects;
+
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+
+public class StatefulSteps {
+
+    String state;
+
+    @Given("the state {string}")
+    public void theState(String state) {
+        this.state = state;
+    }
+
+    @Then("the state is not initialized")
+    public void theStateIsNotInitialized() {
+        assert state == null;
+    }
+
+    @Then("the state is {string}")
+    public void theStateIs(String state) {
+        assert Objects.equals(this.state, state);
+    }
+}

--- a/integration-tests/src/test/resources/simple.feature
+++ b/integration-tests/src/test/resources/simple.feature
@@ -3,3 +3,10 @@ Feature: Test feature
   Scenario: Test scenario
     Given I call the endpoint
     Then the response is ok
+
+  Scenario: Test initialized stateful scenario
+    Given the state "ok"
+    Then the state is "ok"
+
+  Scenario: Test non initialized stateful scenario
+    Then the state is not initialized

--- a/runtime/src/main/java/io/quarkiverse/cucumber/ScenarioContext.java
+++ b/runtime/src/main/java/io/quarkiverse/cucumber/ScenarioContext.java
@@ -1,0 +1,95 @@
+package io.quarkiverse.cucumber;
+
+import java.lang.annotation.Annotation;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.stream.Collectors;
+
+import jakarta.enterprise.context.spi.Contextual;
+import jakarta.enterprise.context.spi.CreationalContext;
+
+import io.quarkus.arc.ContextInstanceHandle;
+import io.quarkus.arc.InjectableBean;
+import io.quarkus.arc.InjectableContext;
+import io.quarkus.arc.impl.ContextInstanceHandleImpl;
+
+public class ScenarioContext implements InjectableContext {
+
+    private final ConcurrentMap<Contextual<?>, ContextInstanceHandle<?>> instances = new ConcurrentHashMap<>();
+    private final Lock beanLock = new ReentrantLock();
+
+    @Override
+    public void destroy() {
+        for (var contextInstanceHandle : instances.values()) {
+            contextInstanceHandle.destroy();
+        }
+        instances.clear();
+    }
+
+    @Override
+    public void destroy(Contextual<?> contextual) {
+        try (var contextInstanceHandle = instances.remove(contextual)) {
+            if (contextInstanceHandle != null) {
+                contextInstanceHandle.destroy();
+            }
+        }
+    }
+
+    @Override
+    public Class<? extends Annotation> getScope() {
+        return ScenarioScope.class;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> T get(Contextual<T> contextual, CreationalContext<T> creationalContext) {
+        var contextInstanceHandle = (ContextInstanceHandle<T>) instances.get(contextual);
+        if (contextInstanceHandle != null) {
+            return contextInstanceHandle.get();
+        } else if (creationalContext != null) {
+            beanLock.lock();
+            try {
+                T createdInstance = contextual.create(creationalContext);
+                instances.put(
+                        contextual,
+                        new ContextInstanceHandleImpl<>(
+                                (InjectableBean<T>) contextual,
+                                createdInstance,
+                                creationalContext));
+                return createdInstance;
+            } finally {
+                beanLock.unlock();
+            }
+        } else {
+            return null;
+        }
+    }
+
+    @Override
+    public <T> T get(Contextual<T> contextual) {
+        return get(contextual, null);
+    }
+
+    @Override
+    public boolean isActive() {
+        return true;
+    }
+
+    @Override
+    public ContextState getState() {
+        return new ScenarioContextState(instances);
+    }
+
+    private record ScenarioContextState(
+            Map<Contextual<?>, ContextInstanceHandle<?>> instances) implements ContextState {
+
+        @Override
+        public Map<InjectableBean<?>, Object> getContextualInstances() {
+            return instances.values().stream()
+                    .collect(Collectors.toMap(ContextInstanceHandle::getBean, ContextInstanceHandle::get));
+        }
+    }
+}

--- a/runtime/src/main/java/io/quarkiverse/cucumber/ScenarioScope.java
+++ b/runtime/src/main/java/io/quarkiverse/cucumber/ScenarioScope.java
@@ -1,0 +1,17 @@
+package io.quarkiverse.cucumber;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import jakarta.enterprise.context.NormalScope;
+
+@NormalScope
+@Retention(RUNTIME)
+@Target({ TYPE, METHOD, FIELD })
+public @interface ScenarioScope {
+}


### PR DESCRIPTION
### Description

This pull request introduces the `@ScenarioScope` annotation, allowing users to utilize stateful beans in Cucumber tests without needing to manually reset the state between scenarios. This functionality is similar to what exists in Spring and Guice, as referenced in the [Cucumber documentation](https://cucumber.io/docs/cucumber/state/?lang=java).

Through the tests I've conducted, this implementation behaves as expected. However, since this is my first deep dive into a Quarkus extension, I would appreciate feedback on a few specific areas:

#### Key Points for Review:

1. **CucumberProcessor.java**:
    - I changed the scope of "step beans" from `@Singleton` to `@ScenarioScope`. While this change aligns with scenario-based state management, it is potentially contentious. I believe `@ScenarioScope` provides better context for step beans, but I'm open to discussion.

2. **simple.feature**:
    - These tests demonstrate that state is isolated between scenarios. If they are unclear or unnecessary, I'm happy to refine or remove them based on your feedback.

3. **ScenarioContext.java**:
    - This class is largely inspired by [TransactionContext](https://github.com/quarkusio/quarkus/blob/main/extensions/narayana-jta/runtime/src/main/java/io/quarkus/narayana/jta/runtime/context/TransactionContext.java). Let me know if this approach is appropriate or if there are improvements to be made.

### Conclusion

Any feedback on this pull request is greatly appreciated. I believe this feature would be a valuable addition to the Quarkus Cucumber extension, and I look forward to your thoughts!
