### PR TITLE
Fix @CucumberOptions ignored on proxied classes

### DIFF
--- a/integration-tests/src/test/java/io/quarkiverse/cucumber/it/Steps.java
+++ b/integration-tests/src/test/java/io/quarkiverse/cucumber/it/Steps.java
@@ -6,11 +6,13 @@ import jakarta.inject.Inject;
 
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
+import io.cucumber.java.en.And;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.restassured.response.ValidatableResponse;
 
 public class Steps {
+    private static boolean fail = false;
 
     @Inject
     @ConfigProperty(name = "testPath", defaultValue = "/")
@@ -35,4 +37,18 @@ public class Steps {
         result.statusCode(200);
     }
 
+    @And("controlled failure")
+    public void controlled_failure() throws Exception {
+        if (fail) {
+            throw new AssertionError("Unexpected failure");
+        }
+    }
+
+    public static void enableControlledFailure() {
+        fail = true;
+    }
+
+    public static void disableControlledFailure() {
+        fail = false;
+    }
 }

--- a/integration-tests/src/test/java/io/quarkiverse/cucumber/it/options/CucumberOptionsTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/cucumber/it/options/CucumberOptionsTest.java
@@ -1,10 +1,24 @@
 package io.quarkiverse.cucumber.it.options;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+
 import io.quarkiverse.cucumber.CucumberOptions;
 import io.quarkiverse.cucumber.CucumberQuarkusTest;
+import io.quarkiverse.cucumber.it.Steps;
 
 @CucumberOptions(glue = { "io.quarkiverse.cucumber.it" }, tags = "@important", plugin = { "json" })
 public class CucumberOptionsTest extends CucumberQuarkusTest {
+    @BeforeEach
+    public void before() {
+        Steps.enableControlledFailure();
+    }
+
+    @AfterEach
+    public void after() {
+        Steps.disableControlledFailure();
+    }
+
     public static void main(String[] args) {
         runMain(CucumberOptionsTest.class, args);
     }

--- a/integration-tests/src/test/resources/out_of_defined_scope.feature
+++ b/integration-tests/src/test/resources/out_of_defined_scope.feature
@@ -1,0 +1,4 @@
+Feature: That should not be run if subpackage is declared
+  @important
+  Scenario: That does nothing unless it's run from CucumberOptionsTest
+    And controlled failure


### PR DESCRIPTION
I have a project with two separate sets of features I wanted to run separately.
After upgrading from 1.1.0 to 1.2.0 is stopped working.

Debug shos that this line in `CucucmberQuarcusTest.getTests()`
```
        if (optionsProvider.hasOptions(this.getClass())) {
```
resolves to false in 1.2.0, because the test class is being proxied by something (probably related to `@ScenarioScope` feature).