### PR TITLE
Fix: use filesystem paths instead of URIs for feature locations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,8 +22,8 @@
     <tag>HEAD</tag>
   </scm>
   <properties>
-    <quarkus.version>3.23.2</quarkus.version>
-    <cucumber.version>7.31.0</cucumber.version>
+    <quarkus.version>3.30.5</quarkus.version>
+    <cucumber.version>7.33.0</cucumber.version>
   </properties>
   <dependencyManagement>
     <dependencies>

--- a/runtime/src/main/java/io/quarkiverse/cucumber/CucumberQuarkusTest.java
+++ b/runtime/src/main/java/io/quarkiverse/cucumber/CucumberQuarkusTest.java
@@ -1,6 +1,8 @@
 package io.quarkiverse.cucumber;
 
 import java.net.URI;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.time.Clock;
 import java.util.Collections;
 import java.util.LinkedList;
@@ -261,7 +263,7 @@ public abstract class CucumberQuarkusTest {
         //--strict/--no-strict is already handled by the CommandlineOptionsParser EXECUTION_STRICT_PROPERTY_NAME
         System.setProperty(Constants.WIP_PROPERTY_NAME, String.valueOf(runtimeOptions.isWip()));
         System.setProperty(Constants.FEATURES_PROPERTY_NAME,
-                runtimeOptions.getFeaturePaths().stream().map(URI::toString).collect(Collectors.joining(",")));
+                runtimeOptions.getFeaturePaths().stream().map(Paths::get).map(Path::toString).collect(Collectors.joining(",")));
         System.setProperty(Constants.FILTER_NAME_PROPERTY_NAME,
                 runtimeOptions.getNameFilters().stream().map(Pattern::toString).collect(Collectors.joining(",")));
         System.setProperty(Constants.FILTER_TAGS_PROPERTY_NAME,


### PR DESCRIPTION
Fix needed due to changes done in https://github.com/cucumber/cucumber-jvm/pull/3098
Without this change it's not possible (at least on windows machines) to run a single feature file within IntelliJ. Leads to the following error:
```java
io.cucumber.core.exception.CucumberException: Failed to parse 'cucumber.features' with value 'file:///D:/randomproject/random.feature'
io.cucumber.core.options.CucumberPropertiesParser.parseAll(CucumberPropertiesParser.java:167)
io.cucumber.core.options.CucumberPropertiesParser.parse(CucumberPropertiesParser.java:68)
io.cucumber.core.options.CucumberPropertiesParser.parse(CucumberPropertiesParser.java:42)
io.quarkiverse.cucumber.CucumberQuarkusTest.getTests(CucumberQuarkusTest.java:75)
``` 

Also bumped quarkus and cucumber to latest versions available to verify it works in my project.

If approved, can a new release be made so this fix can be used? Thanks in advance!