### PR TITLE
ci: Add JDK 21 to build matrix and fix deprecated set-output

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,22 +24,25 @@ on:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        java: [17, 21]
 
     steps:
     - uses: actions/checkout@v4
 
-    - name: Set up JDK 17
+    - name: Set up JDK ${{ matrix.java }}
       uses: actions/setup-java@v4
       with:
-        java-version: 17
+        java-version: ${{ matrix.java }}
         distribution: temurin
 
     - name: Get Date
       id: get-date
       run: |
-        echo "::set-output name=date::$(/bin/date -u "+%Y-%m")"
+        echo "date=$(/bin/date -u "+%Y-%m")" >> $GITHUB_OUTPUT
       shell: bash
     - name: Cache Maven Repository
       id: cache-maven
@@ -47,8 +50,7 @@ jobs:
       with:
         path: ~/.m2/repository
         # refresh cache every month to avoid unlimited growth
-        key: maven-repo-${{ runner.os }}-${{ steps.get-date.outputs.date }}
+        key: maven-repo-${{ runner.os }}-${{ matrix.java }}-${{ steps.get-date.outputs.date }}
 
     - name: Build with Maven
       run: mvn -B formatter:validate verify --file pom.xml
-


### PR DESCRIPTION
- Add matrix strategy with JDK 17 and 21
- Replace deprecated ::set-output with GITHUB_OUTPUT
- Include Java version in cache key for proper isolation