### PR TITLE
feat: add pretty option to @CucumberOptions to disable PrettyFormatter

### DIFF
--- a/runtime/src/main/java/io/quarkiverse/cucumber/CucumberOptions.java
+++ b/runtime/src/main/java/io/quarkiverse/cucumber/CucumberOptions.java
@@ -116,6 +116,11 @@ public @interface CucumberOptions {
     SnippetType snippets() default SnippetType.UNDERSCORE;
 
     /**
+     * @return false to disable the default {@code PrettyFormatter} output.
+     */
+    boolean pretty() default true;
+
+    /**
      * Specify a custom ObjectFactory.
      * <p>
      * In case a custom ObjectFactory is needed, the class can be specified

--- a/runtime/src/main/java/io/quarkiverse/cucumber/CucumberQuarkusTest.java
+++ b/runtime/src/main/java/io/quarkiverse/cucumber/CucumberQuarkusTest.java
@@ -100,7 +100,10 @@ public abstract class CucumberQuarkusTest {
                 runtimeOptions, parser);
 
         final Plugins plugins = new Plugins(new PluginFactory(), runtimeOptions);
-        plugins.addPlugin(new PrettyFormatter(System.out));
+        if (testClassWithCucumberOptions == null
+                || testClassWithCucumberOptions.getAnnotation(CucumberOptions.class).pretty()) {
+            plugins.addPlugin(new PrettyFormatter(System.out));
+        }
 
         final ExitStatus exitStatus = new ExitStatus(runtimeOptions);
         plugins.addPlugin(exitStatus);


### PR DESCRIPTION
## Summary

Adds a `pretty` attribute to `@CucumberOptions` that allows users to disable the default `PrettyFormatter` output. The formatter is still enabled by default for backwards compatibility.

## Changes

- Added `boolean pretty() default true;` to `@CucumberOptions`
- `CucumberQuarkusTest` now conditionally adds `PrettyFormatter` based on the annotation value; when no `@CucumberOptions` annotation is present, the formatter is added as before