### PR TITLE
Fix for #298 and added @CucumberOptions glue to avoid classpath errors during build

### DIFF
--- a/deployment/src/test/java/io/quarkiverse/cucumber/test/BasicTest.java
+++ b/deployment/src/test/java/io/quarkiverse/cucumber/test/BasicTest.java
@@ -1,7 +1,13 @@
 package io.quarkiverse.cucumber.test;
 
+import io.quarkiverse.cucumber.CucumberOptions;
 import io.quarkiverse.cucumber.CucumberQuarkusTest;
 
+@CucumberOptions(glue = { "io.quarkiverse.cucumber.test" })
 public class BasicTest extends CucumberQuarkusTest {
+
+    public static void main(String[] args) {
+        runMain(BasicTest.class, args);
+    }
 
 }

--- a/integration-tests/src/test/java/io/quarkiverse/cucumber/it/CucumberResourceTest.java
+++ b/integration-tests/src/test/java/io/quarkiverse/cucumber/it/CucumberResourceTest.java
@@ -1,7 +1,9 @@
 package io.quarkiverse.cucumber.it;
 
+import io.quarkiverse.cucumber.CucumberOptions;
 import io.quarkiverse.cucumber.CucumberQuarkusTest;
 
+@CucumberOptions(glue = { "io.quarkiverse.cucumber.it" })
 public class CucumberResourceTest extends CucumberQuarkusTest {
     public static void main(String[] args) {
         runMain(CucumberResourceTest.class, args);

--- a/runtime/src/main/java/io/quarkiverse/cucumber/CucumberQuarkusTest.java
+++ b/runtime/src/main/java/io/quarkiverse/cucumber/CucumberQuarkusTest.java
@@ -306,6 +306,6 @@ public abstract class CucumberQuarkusTest {
         System.setProperty(Constants.SNIPPET_TYPE_PROPERTY_NAME,
                 runtimeOptions.getSnippetType().toString().toLowerCase());
 
-        ConsoleLauncher.main("-c", testClass.getName());
+        ConsoleLauncher.main("execute", "-c", testClass.getName());
     }
 }


### PR DESCRIPTION
Fixes #298

Junit 6 (as used from Quarkus 3.31) requires an "execution" argument for the runner to engage properly.

Also added @CucumberOptions to avoid classloading stack traces in build logs.
